### PR TITLE
Secure registration/login, env DB config, and frontend fixes

### DIFF
--- a/AquaLimpaOficial-main/backend/cadastro.php
+++ b/AquaLimpaOficial-main/backend/cadastro.php
@@ -1,35 +1,70 @@
 <?php
 require 'conexao.php';
 
-if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-    $nome = trim($_POST['nome'] ?? '');
-    $dtnasc = $_POST['data_nascimento'] ?? null;
-    $email = trim($_POST['email'] ?? '');
-    $senha = $_POST['senha'] ?? '';
-
-    if ($nome === '' || $email === '' || $senha === '') {
-        die('Erro: preencha os campos obrigatórios (nome, e-mail e senha).');
-    }
-
-    $senhaHash = password_hash($senha, PASSWORD_DEFAULT);
-
-    $sql = "INSERT INTO usuario (nome, dtnasc, email, senha) VALUES (?, ?, ?, ?)";
-    $stmt = mysqli_prepare($conexao, $sql);
-
-    if (!$stmt) {
-        die("Erro ao preparar cadastro: " . mysqli_error($conexao));
-    }
-
-    mysqli_stmt_bind_param($stmt, "ssss", $nome, $dtnasc, $email, $senhaHash);
-
-    if (mysqli_stmt_execute($stmt)) {
-        header("Location: ../index.html");
-        exit;
-    }
-
-    echo "Erro ao cadastrar: " . mysqli_error($conexao);
-    mysqli_stmt_close($stmt);
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit('Método não permitido.');
 }
 
+$nome = trim($_POST['nome'] ?? '');
+$dtnasc = $_POST['data_nascimento'] ?? null;
+$email = trim($_POST['email'] ?? '');
+$senha = $_POST['senha'] ?? '';
 
+if ($nome === '' || $email === '' || $senha === '' || $dtnasc === null || $dtnasc === '') {
+    http_response_code(422);
+    exit('Erro: preencha todos os campos obrigatórios.');
+}
+
+if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    http_response_code(422);
+    exit('Erro: e-mail inválido.');
+}
+
+if (strlen($senha) < 8) {
+    http_response_code(422);
+    exit('Erro: a senha deve ter no mínimo 8 caracteres.');
+}
+
+$checkSql = 'SELECT id FROM usuario WHERE email = ? LIMIT 1';
+$checkStmt = mysqli_prepare($conexao, $checkSql);
+if (!$checkStmt) {
+    error_log('Erro ao preparar verificação de e-mail: ' . mysqli_error($conexao));
+    http_response_code(500);
+    exit('Erro interno. Tente novamente mais tarde.');
+}
+
+mysqli_stmt_bind_param($checkStmt, 's', $email);
+mysqli_stmt_execute($checkStmt);
+mysqli_stmt_store_result($checkStmt);
+
+if (mysqli_stmt_num_rows($checkStmt) > 0) {
+    mysqli_stmt_close($checkStmt);
+    http_response_code(409);
+    exit('Erro: e-mail já cadastrado.');
+}
+mysqli_stmt_close($checkStmt);
+
+$senhaHash = password_hash($senha, PASSWORD_DEFAULT);
+$sql = 'INSERT INTO usuario (nome, dtnasc, email, senha) VALUES (?, ?, ?, ?)';
+$stmt = mysqli_prepare($conexao, $sql);
+
+if (!$stmt) {
+    error_log('Erro ao preparar cadastro: ' . mysqli_error($conexao));
+    http_response_code(500);
+    exit('Erro interno. Tente novamente mais tarde.');
+}
+
+mysqli_stmt_bind_param($stmt, 'ssss', $nome, $dtnasc, $email, $senhaHash);
+
+if (mysqli_stmt_execute($stmt)) {
+    mysqli_stmt_close($stmt);
+    header('Location: ../pages/login.html');
+    exit;
+}
+
+error_log('Erro ao cadastrar: ' . mysqli_error($conexao));
+mysqli_stmt_close($stmt);
+http_response_code(500);
+exit('Erro interno. Tente novamente mais tarde.');
 ?>

--- a/AquaLimpaOficial-main/backend/conexao.php
+++ b/AquaLimpaOficial-main/backend/conexao.php
@@ -1,13 +1,15 @@
 <?php
-$servidor = "localhost";
-$usuario = "root";
-$senha = "123456";
-$banco = "AQUALIMPA";
+$servidor = getenv('DB_HOST') ?: 'localhost';
+$usuario = getenv('DB_USER') ?: 'root';
+$senha = getenv('DB_PASS') ?: '';
+$banco = getenv('DB_NAME') ?: 'AQUALIMPA';
 
+mysqli_report(MYSQLI_REPORT_OFF);
 $conexao = mysqli_connect($servidor, $usuario, $senha, $banco);
+
 if (!$conexao) {
-    die("Erro na conexão: " . mysqli_connect_error());
-} else {
-    // echo "Conexão bem-sucedida!";
+    error_log('Erro na conexão com o banco de dados: ' . mysqli_connect_error());
+    http_response_code(500);
+    exit('Erro interno. Tente novamente mais tarde.');
 }
 ?>

--- a/AquaLimpaOficial-main/backend/login.php
+++ b/AquaLimpaOficial-main/backend/login.php
@@ -1,0 +1,42 @@
+<?php
+session_start();
+require 'conexao.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit('Método não permitido.');
+}
+
+$email = trim($_POST['email'] ?? '');
+$senha = $_POST['senha'] ?? '';
+
+if ($email === '' || $senha === '') {
+    http_response_code(422);
+    exit('Erro: informe e-mail e senha.');
+}
+
+$sql = 'SELECT id, nome, senha FROM usuario WHERE email = ? LIMIT 1';
+$stmt = mysqli_prepare($conexao, $sql);
+if (!$stmt) {
+    error_log('Erro ao preparar login: ' . mysqli_error($conexao));
+    http_response_code(500);
+    exit('Erro interno. Tente novamente mais tarde.');
+}
+
+mysqli_stmt_bind_param($stmt, 's', $email);
+mysqli_stmt_execute($stmt);
+$result = mysqli_stmt_get_result($stmt);
+$user = mysqli_fetch_assoc($result);
+mysqli_stmt_close($stmt);
+
+if (!$user || !password_verify($senha, $user['senha'])) {
+    http_response_code(401);
+    exit('Credenciais inválidas.');
+}
+
+$_SESSION['usuario_id'] = $user['id'];
+$_SESSION['usuario_nome'] = $user['nome'];
+
+header('Location: ../index.html');
+exit;
+?>

--- a/AquaLimpaOficial-main/index.html
+++ b/AquaLimpaOficial-main/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Aqua Limpa</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"> <!-- Fonte para ícones -->
-  <link rel="stylesheet" href="assets/css/index.css>
+  <link rel="stylesheet" href="assets/css/index.css">
 </head>
 <body>
 

--- a/AquaLimpaOficial-main/pages/criarconta.html
+++ b/AquaLimpaOficial-main/pages/criarconta.html
@@ -89,7 +89,7 @@
       <input type="email" id="email" name="email" placeholder="Insira seu texto" required>
 
       <label for="senha">SENHA</label>
-      <input type="password" id="senha" name="senha" placeholder="Insira seu texto" required>
+      <input type="password" id="senha" name="senha" placeholder="Mínimo 8 caracteres" minlength="8" required>
 
       <button type="submit" class="btn-cadastrar">Cadastrar</button>
     </form>

--- a/AquaLimpaOficial-main/pages/login.html
+++ b/AquaLimpaOficial-main/pages/login.html
@@ -102,7 +102,7 @@
   </style>
 </head>
 <body>
-  <form action="../index.html" method="GET">
+  <form action="../backend/login.php" method="POST">
     <div class="container">
       <h1 class="title"><span>AQUA</span> <span>LIMPA</span></h1>
 


### PR DESCRIPTION
### Motivation
- Harden user registration and login by adding input validation, password hashing, duplicate-email checks, and proper HTTP method handling.
- Centralize database configuration using environment variables and improve error handling to avoid leaking sensitive information.
- Fix front-end form targets and small markup issues to connect pages to the new backend endpoints.

### Description
- Replace permissive `cadastro.php` flow with strict `POST` method checks, required field validation, email format and password length checks, duplicate-email query, `password_hash` storage, prepared statements, and improved error logging and HTTP responses; successful registration now redirects to `pages/login.html`.
- Add `login.php` which starts a session, validates `POST` credentials, verifies passwords with `password_verify`, sets session values, and redirects on success, with prepared statements and error handling on failure.
- Update `conexao.php` to read DB credentials from environment variables (`DB_HOST`, `DB_USER`, `DB_PASS`, `DB_NAME`), disable noisy MySQLi reporting, and return a controlled 500 error on connection failure while logging details.
- Fix front-end issues by correcting the stylesheet link in `index.html`, setting `minlength=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe937dbf3483329cec8d28367436d9)