### PR TITLE
Add authentication backend with CSRF, sessions, rate-limiting and DB refactor

### DIFF
--- a/AquaLimpaOficial-main/backend/conexao.php
+++ b/AquaLimpaOficial-main/backend/conexao.php
@@ -1,13 +1,15 @@
 <?php
-$servidor = "localhost";
-$usuario = "root";
-$senha = "123456";
-$banco = "AQUALIMPA";
+$servidor = getenv('DB_HOST') ?: 'localhost';
+$usuario = getenv('DB_USER') ?: 'root';
+$senha = getenv('DB_PASS') ?: '';
+$banco = getenv('DB_NAME') ?: 'AQUALIMPA';
 
+mysqli_report(MYSQLI_REPORT_OFF);
 $conexao = mysqli_connect($servidor, $usuario, $senha, $banco);
+
 if (!$conexao) {
-    die("Erro na conexão: " . mysqli_connect_error());
-} else {
-    // echo "Conexão bem-sucedida!";
+    error_log('Erro na conexão com o banco de dados: ' . mysqli_connect_error());
+    http_response_code(500);
+    exit('Erro interno. Tente novamente mais tarde.');
 }
 ?>

--- a/AquaLimpaOficial-main/backend/controllers/AuthController.php
+++ b/AquaLimpaOficial-main/backend/controllers/AuthController.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__ . '/../services/AuthService.php';
+require_once __DIR__ . '/../utils/response.php';
+
+class AuthController
+{
+    public function __construct(private AuthService $service)
+    {
+    }
+
+    public function register(array $data): void
+    {
+        $nome = trim($data['nome'] ?? '');
+        $dtnasc = trim($data['data_nascimento'] ?? '');
+        $email = trim($data['email'] ?? '');
+        $senha = $data['senha'] ?? '';
+
+        if ($nome === '' || $dtnasc === '' || $email === '' || $senha === '') {
+            jsonResponse(422, ['ok' => false, 'message' => 'Preencha todos os campos obrigatórios.']);
+        }
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            jsonResponse(422, ['ok' => false, 'message' => 'E-mail inválido.']);
+        }
+        if (strlen($senha) < 8) {
+            jsonResponse(422, ['ok' => false, 'message' => 'A senha deve ter no mínimo 8 caracteres.']);
+        }
+
+        [$ok, $message, $status] = $this->service->register($nome, $dtnasc, $email, $senha);
+        jsonResponse($status, ['ok' => $ok, 'message' => $message]);
+    }
+
+    public function login(array $data): void
+    {
+        $email = trim($data['email'] ?? '');
+        $senha = $data['senha'] ?? '';
+
+        if ($email === '' || $senha === '') {
+            jsonResponse(422, ['ok' => false, 'message' => 'Informe e-mail e senha.']);
+        }
+
+        [$ok, $message, $status, $user] = $this->service->login($email, $senha);
+        if (!$ok) {
+            jsonResponse($status, ['ok' => false, 'message' => $message]);
+        }
+
+        session_regenerate_id(true);
+        $_SESSION['usuario_id'] = $user['id'];
+        $_SESSION['usuario_nome'] = $user['nome'];
+
+        jsonResponse(200, ['ok' => true, 'message' => $message]);
+    }
+}
+?>

--- a/AquaLimpaOficial-main/backend/csrf.php
+++ b/AquaLimpaOficial-main/backend/csrf.php
@@ -1,0 +1,9 @@
+<?php
+require_once __DIR__ . '/middlewares/SessionMiddleware.php';
+require_once __DIR__ . '/middlewares/CsrfMiddleware.php';
+require_once __DIR__ . '/utils/response.php';
+
+startSecureSession();
+$token = ensureCsrfToken();
+jsonResponse(200, ['ok' => true, 'csrf_token' => $token]);
+?>

--- a/AquaLimpaOficial-main/backend/login.php
+++ b/AquaLimpaOficial-main/backend/login.php
@@ -2,25 +2,29 @@
 require 'conexao.php';
 require_once __DIR__ . '/middlewares/SessionMiddleware.php';
 require_once __DIR__ . '/middlewares/CsrfMiddleware.php';
+require_once __DIR__ . '/middlewares/RateLimiter.php';
 require_once __DIR__ . '/controllers/AuthController.php';
+require_once __DIR__ . '/utils/response.php';
 
 startSecureSession();
 $csrfToken = ensureCsrfToken();
 header('X-CSRF-Token: ' . $csrfToken);
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    require_once __DIR__ . '/utils/response.php';
     jsonResponse(405, ['ok' => false, 'message' => 'Método não permitido.']);
 }
 
 if (!verifyCsrfToken()) {
-    require_once __DIR__ . '/utils/response.php';
     jsonResponse(403, ['ok' => false, 'message' => 'CSRF token inválido.']);
 }
 
+$clientKey = ($_SERVER['REMOTE_ADDR'] ?? 'unknown') . ':' . ($_POST['email'] ?? '');
+if (!throttleLogin($clientKey)) {
+    jsonResponse(429, ['ok' => false, 'message' => 'Muitas tentativas. Aguarde alguns minutos.']);
+}
+
 $userRepository = new UserRepository($conexao);
-$userRepository->ensureEmailUniqueIndex();
 $service = new AuthService($userRepository);
 $controller = new AuthController($service);
-$controller->register($_POST);
+$controller->login($_POST);
 ?>

--- a/AquaLimpaOficial-main/backend/middlewares/CsrfMiddleware.php
+++ b/AquaLimpaOficial-main/backend/middlewares/CsrfMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+function ensureCsrfToken(): string
+{
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function verifyCsrfToken(): bool
+{
+    $provided = $_POST['csrf_token'] ?? ($_SERVER['HTTP_X_CSRF_TOKEN'] ?? '');
+    return isset($_SESSION['csrf_token']) && hash_equals($_SESSION['csrf_token'], (string) $provided);
+}
+?>

--- a/AquaLimpaOficial-main/backend/middlewares/RateLimiter.php
+++ b/AquaLimpaOficial-main/backend/middlewares/RateLimiter.php
@@ -1,0 +1,26 @@
+<?php
+function throttleLogin(string $key, int $limit = 5, int $windowSeconds = 300): bool
+{
+    $dir = sys_get_temp_dir() . '/aqualimpa_rate_limit';
+    if (!is_dir($dir)) {
+        mkdir($dir, 0700, true);
+    }
+
+    $file = $dir . '/' . hash('sha256', $key) . '.json';
+    $now = time();
+    $attempts = [];
+
+    if (file_exists($file)) {
+        $attempts = json_decode((string) file_get_contents($file), true) ?: [];
+    }
+
+    $attempts = array_filter($attempts, fn ($ts) => ($now - (int) $ts) <= $windowSeconds);
+    if (count($attempts) >= $limit) {
+        return false;
+    }
+
+    $attempts[] = $now;
+    file_put_contents($file, json_encode(array_values($attempts)));
+    return true;
+}
+?>

--- a/AquaLimpaOficial-main/backend/middlewares/SessionMiddleware.php
+++ b/AquaLimpaOficial-main/backend/middlewares/SessionMiddleware.php
@@ -1,0 +1,21 @@
+<?php
+function startSecureSession(): void
+{
+    if (session_status() === PHP_SESSION_NONE) {
+        session_set_cookie_params([
+            'httponly' => true,
+            'samesite' => 'Lax',
+            'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
+        ]);
+        session_start();
+    }
+
+    $timeout = 1800;
+    if (isset($_SESSION['last_activity']) && (time() - $_SESSION['last_activity']) > $timeout) {
+        session_unset();
+        session_destroy();
+        session_start();
+    }
+    $_SESSION['last_activity'] = time();
+}
+?>

--- a/AquaLimpaOficial-main/backend/repositories/UserRepository.php
+++ b/AquaLimpaOficial-main/backend/repositories/UserRepository.php
@@ -1,0 +1,42 @@
+<?php
+class UserRepository
+{
+    public function __construct(private mysqli $db)
+    {
+    }
+
+    public function findByEmail(string $email): ?array
+    {
+        $sql = 'SELECT id, nome, email, senha FROM usuario WHERE email = ? LIMIT 1';
+        $stmt = mysqli_prepare($this->db, $sql);
+        if (!$stmt) {
+            return null;
+        }
+        mysqli_stmt_bind_param($stmt, 's', $email);
+        mysqli_stmt_execute($stmt);
+        $result = mysqli_stmt_get_result($stmt);
+        $user = mysqli_fetch_assoc($result) ?: null;
+        mysqli_stmt_close($stmt);
+        return $user;
+    }
+
+    public function create(string $nome, string $dtnasc, string $email, string $senhaHash): bool
+    {
+        $sql = 'INSERT INTO usuario (nome, dtnasc, email, senha) VALUES (?, ?, ?, ?)';
+        $stmt = mysqli_prepare($this->db, $sql);
+        if (!$stmt) {
+            return false;
+        }
+        mysqli_stmt_bind_param($stmt, 'ssss', $nome, $dtnasc, $email, $senhaHash);
+        $ok = mysqli_stmt_execute($stmt);
+        mysqli_stmt_close($stmt);
+        return $ok;
+    }
+
+    public function ensureEmailUniqueIndex(): void
+    {
+        $sql = 'ALTER TABLE usuario ADD UNIQUE KEY uniq_usuario_email (email)';
+        @mysqli_query($this->db, $sql);
+    }
+}
+?>

--- a/AquaLimpaOficial-main/backend/services/AuthService.php
+++ b/AquaLimpaOficial-main/backend/services/AuthService.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../repositories/UserRepository.php';
+
+class AuthService
+{
+    public function __construct(private UserRepository $users)
+    {
+    }
+
+    public function register(string $nome, string $dtnasc, string $email, string $senha): array
+    {
+        if ($this->users->findByEmail($email)) {
+            return [false, 'E-mail já cadastrado.', 409];
+        }
+
+        $hash = password_hash($senha, PASSWORD_DEFAULT);
+        if (!$this->users->create($nome, $dtnasc, $email, $hash)) {
+            return [false, 'Erro ao cadastrar usuário.', 500];
+        }
+
+        return [true, 'Cadastro realizado com sucesso.', 201];
+    }
+
+    public function login(string $email, string $senha): array
+    {
+        $user = $this->users->findByEmail($email);
+        if (!$user || !password_verify($senha, $user['senha'])) {
+            return [false, 'Credenciais inválidas.', 401, null];
+        }
+
+        return [true, 'Login realizado com sucesso.', 200, $user];
+    }
+}
+?>

--- a/AquaLimpaOficial-main/backend/utils/response.php
+++ b/AquaLimpaOficial-main/backend/utils/response.php
@@ -1,0 +1,9 @@
+<?php
+function jsonResponse(int $status, array $payload): void
+{
+    http_response_code($status);
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+    exit;
+}
+?>

--- a/AquaLimpaOficial-main/index.html
+++ b/AquaLimpaOficial-main/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Aqua Limpa</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"> <!-- Fonte para ícones -->
-  <link rel="stylesheet" href="assets/css/index.css>
+  <link rel="stylesheet" href="assets/css/index.css">
 </head>
 <body>
 

--- a/AquaLimpaOficial-main/pages/criarconta.html
+++ b/AquaLimpaOficial-main/pages/criarconta.html
@@ -89,10 +89,21 @@
       <input type="email" id="email" name="email" placeholder="Insira seu texto" required>
 
       <label for="senha">SENHA</label>
-      <input type="password" id="senha" name="senha" placeholder="Insira seu texto" required>
+      <input type="password" id="senha" name="senha" placeholder="Mínimo 8 caracteres" minlength="8" required>
 
       <button type="submit" class="btn-cadastrar">Cadastrar</button>
+          <input type="hidden" name="csrf_token" id="csrf_token">
     </form>
   </div>
+  <script>
+    fetch("../backend/csrf.php", { credentials: "same-origin" })
+      .then(r => r.json())
+      .then(data => {
+        if (data && data.csrf_token) {
+          const el = document.getElementById("csrf_token");
+          if (el) el.value = data.csrf_token;
+        }
+      });
+  </script>
 </body>
 </html>

--- a/AquaLimpaOficial-main/pages/login.html
+++ b/AquaLimpaOficial-main/pages/login.html
@@ -102,7 +102,7 @@
   </style>
 </head>
 <body>
-  <form action="../index.html" method="GET">
+  <form action="../backend/login.php" method="POST">
     <div class="container">
       <h1 class="title"><span>AQUA</span> <span>LIMPA</span></h1>
 
@@ -122,6 +122,17 @@
         <img src="https://cdn-icons-png.flaticon.com/512/124/124010.png" alt="Facebook">
       </div>
     </div>
-  </form>
+        <input type="hidden" name="csrf_token" id="csrf_token">
+    </form>
+  <script>
+    fetch("../backend/csrf.php", { credentials: "same-origin" })
+      .then(r => r.json())
+      .then(data => {
+        if (data && data.csrf_token) {
+          const el = document.getElementById("csrf_token");
+          if (el) el.value = data.csrf_token;
+        }
+      });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace ad-hoc registration/login scripts with a small, safer auth stack to improve security and maintainability.
- Introduce CSRF protection, secure session handling and basic rate limiting to mitigate common web attack vectors.
- Make database credentials configurable via environment variables and improve error handling for DB connection failures.

### Description
- Added a layered auth implementation including `controllers/AuthController.php`, `services/AuthService.php`, and `repositories/UserRepository.php` to centralize validation and DB access, and updated `cadastro.php` to use the controller flow.
- Implemented security middlewares: `middlewares/SessionMiddleware.php` for secure sessions, `middlewares/CsrfMiddleware.php` for CSRF token management, and `middlewares/RateLimiter.php` to throttle login attempts, plus `utils/response.php` for consistent JSON responses.
- Created `login.php` and `csrf.php` endpoints, added client-side token fetching in `pages/criarconta.html` and `pages/login.html`, changed the login form to POST to `backend/login.php`, and added a hidden `csrf_token` field in forms.
- Refactored `conexao.php` to read DB credentials from environment variables, suppress noisy mysqli reports, and return a safe 500 response with logging on connection failure, and fixed a broken stylesheet link in `index.html` and password minlength in the signup page.

### Testing
- Performed PHP syntax checks with `php -l` on modified PHP files and they passed successfully.
- Ran basic endpoint smoke tests with `curl` against `backend/csrf.php`, `backend/cadastro.php`, and `backend/login.php` to verify HTTP status codes and JSON responses and all returned the expected statuses.
- No new automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe937dbf3483329cec8d28367436d9)